### PR TITLE
Redirect GtkPopover to GtkMenu when environment variable is set

### DIFF
--- a/gtk/gtkmenubutton.c
+++ b/gtk/gtkmenubutton.c
@@ -1165,21 +1165,30 @@ gtk_menu_button_set_popover (GtkMenuButton *menu_button,
       gtk_popover_set_relative_to (GTK_POPOVER (priv->popover), NULL);
     }
 
-  priv->popover = popover;
-
-  if (popover)
+  if (g_strcmp0 (g_getenv ("GTK_POPOVER_TO_MENU"), "1") == 0)
     {
-      gtk_popover_set_relative_to (GTK_POPOVER (priv->popover), GTK_WIDGET (menu_button));
-      g_signal_connect_swapped (priv->popover, "closed",
-                                G_CALLBACK (menu_deactivate_cb), menu_button);
-      g_signal_connect_swapped (priv->popover, "destroy",
-                                G_CALLBACK (popover_destroy_cb), menu_button);
-      update_popover_direction (menu_button);
-      gtk_style_context_remove_class (gtk_widget_get_style_context (GTK_WIDGET (menu_button)), "menu-button");
+      GtkWidget *menu = gtk_menu_new_from_model (priv->model);
+      gtk_menu_button_set_popup (menu_button, menu);
+      priv->popover = NULL;
     }
+  else
+    {
+      priv->popover = popover;
 
-  if (popover && priv->menu)
-    gtk_menu_button_set_popup (menu_button, NULL);
+      if (popover)
+        {
+          gtk_popover_set_relative_to (GTK_POPOVER (priv->popover), GTK_WIDGET (menu_button));
+          g_signal_connect_swapped (priv->popover, "closed",
+                                    G_CALLBACK (menu_deactivate_cb), menu_button);
+          g_signal_connect_swapped (priv->popover, "destroy",
+                                    G_CALLBACK (popover_destroy_cb), menu_button);
+          update_popover_direction (menu_button);
+          gtk_style_context_remove_class (gtk_widget_get_style_context (GTK_WIDGET (menu_button)), "menu-button");
+        }
+
+      if (popover && priv->menu)
+        gtk_menu_button_set_popup (menu_button, NULL);
+    }
 
   update_sensitivity (menu_button);
 

--- a/gtk/gtkpopover.c
+++ b/gtk/gtkpopover.c
@@ -2236,6 +2236,9 @@ gtk_popover_new (GtkWidget *relative_to)
 {
   g_return_val_if_fail (relative_to == NULL || GTK_IS_WIDGET (relative_to), NULL);
 
+  if (g_getenv ("GTK_POPOVER_TO_MENU"))
+    return gtk_menu_new ();
+
   return g_object_new (GTK_TYPE_POPOVER,
                        "relative-to", relative_to,
                        NULL);

--- a/gtk/gtkpopovermenu.c
+++ b/gtk/gtkpopovermenu.c
@@ -20,6 +20,7 @@
 #include "gtkstack.h"
 #include "gtkstylecontext.h"
 #include "gtkintl.h"
+#include <stdlib.h> // for getenv
 
 
 /**
@@ -399,6 +400,8 @@ gtk_popover_menu_class_init (GtkPopoverMenuClass *klass)
 GtkWidget *
 gtk_popover_menu_new (void)
 {
+  if (g_strcmp0 (g_getenv ("GTK_POPOVER_TO_MENU"), "1") == 0)
+    return gtk_menu_new ();
   return g_object_new (GTK_TYPE_POPOVER_MENU, NULL);
 }
 


### PR DESCRIPTION
Use GtkMenu instead of GtkPopover

* Modify `gtk/gtkmenubutton.c` to check the environment variable and use `GtkMenu` instead of `GtkPopover`.
* Modify `gtk/gtkpopover.c` to check the environment variable and return `GtkMenu` instead of `GtkPopover`.
* Modify `gtk/gtkpopovermenu.c` to check the environment variable and return `GtkMenu` instead of `GtkPopover`.

Experimental: Generated with Copilot Workspace